### PR TITLE
Add Cert Manager as a provided GitOps-driven Operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+## Ignore user-generated secrets for some pre-reqs
+*env.secret
+*.secret

--- a/gitops-applications/cert-manager/README.md
+++ b/gitops-applications/cert-manager/README.md
@@ -1,0 +1,3 @@
+# Creating a GitHub Connection to Access Private Repos
+
+Fill out `env.secret` with your GitHub and target repo details before applying this kustomize folder, and ensure the repo URLs match!

--- a/gitops-applications/cert-manager/certmanager.application.yaml
+++ b/gitops-applications/cert-manager/certmanager.application.yaml
@@ -9,8 +9,8 @@ spec:
   project: default
   source:
     path: operators/cert-manager
-    repoURL: 'https://github.com/open-cluster-management/acm-aap-aas-operations'
-    targetRevision: main
+    repoURL: 'https://github.com/open-cluster-management/ci-cluster-config'
+    targetRevision: add-cert-manager
   syncPolicy:
     automated:
       selfHeal: true

--- a/gitops-applications/cert-manager/certmanager.application.yaml
+++ b/gitops-applications/cert-manager/certmanager.application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: openshift-gitops
+spec:
+  destination:
+    name: in-cluster
+  project: default
+  source:
+    path: operators/cert-manager
+    repoURL: 'https://github.com/open-cluster-management/acm-aap-aas-operations'
+    targetRevision: main
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 15 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+        factor: 2 # a factor to multiply the base duration after each failed retry
+        maxDuration: 5m # the maximum amount of time allowed for the backoff strategy

--- a/gitops-applications/cert-manager/github.secret.example
+++ b/gitops-applications/cert-manager/github.secret.example
@@ -1,4 +1,0 @@
-password=<GITHUB_PASSWORD>
-username=<GITHUB_USERNAME>
-url=<GITHUB_REPO_HTTP_URL>
-type=git

--- a/gitops-applications/cert-manager/github.secret.example
+++ b/gitops-applications/cert-manager/github.secret.example
@@ -1,0 +1,4 @@
+password=<GITHUB_PASSWORD>
+username=<GITHUB_USERNAME>
+url=<GITHUB_REPO_HTTP_URL>
+type=git

--- a/gitops-applications/cert-manager/kustomization.yaml
+++ b/gitops-applications/cert-manager/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  labels:
+    argocd.argoproj.io/secret-type: repository
+  disableNameSuffixHash: true
+
+namespace: openshift-gitops
+
+resources:
+- certmanager.application.yaml
+
+secretGenerator:
+- name: aap-aas-repo-config-access
+  envs:
+  - github.secret

--- a/gitops-applications/cert-manager/kustomization.yaml
+++ b/gitops-applications/cert-manager/kustomization.yaml
@@ -1,17 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-generatorOptions:
-  labels:
-    argocd.argoproj.io/secret-type: repository
-  disableNameSuffixHash: true
-
 namespace: openshift-gitops
 
 resources:
 - certmanager.application.yaml
-
-secretGenerator:
-- name: aap-aas-repo-config-access
-  envs:
-  - github.secret

--- a/operators/cert-manager/kustomization.yaml
+++ b/operators/cert-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openshift-operators
+
+resources:
+  - subscription.yaml

--- a/operators/cert-manager/patch/patch-certmanager.sh
+++ b/operators/cert-manager/patch/patch-certmanager.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+oc patch clusterserviceversion cert-manager.v1.6.1 \
+    --type=json \
+    -n openshift-operators \
+    --patch='[{"op":"add","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-","value":"--dns01-recursive-nameservers-only"},{"op":"add","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/args/-","value":"--dns01-recursive-nameservers=8.8.8.8:53,1.1.1.1:53"}]'

--- a/operators/cert-manager/postinstall/api.certificate.yaml
+++ b/operators/cert-manager/postinstall/api.certificate.yaml
@@ -1,0 +1,25 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: api-domain-tls-cert
+  namespace: openshift-config
+  labels:
+    use-dns01-solver: "true"
+spec:
+  secretName: api-domain-tls
+  subject:
+    organizations:
+    - Open Cluster Management
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - api.openshift-cluster-name.base-domain.tld
+  duration: 720h0m0s
+  renewBefore: 168h0m0s
+  privateKey:
+    algorithm: "RSA"
+    size: 2048
+  issuerRef:
+    name: public-issuer
+    kind: ClusterIssuer

--- a/operators/cert-manager/postinstall/apps.certificate.yaml
+++ b/operators/cert-manager/postinstall/apps.certificate.yaml
@@ -1,0 +1,26 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: apps-domain-tls-cert
+  namespace: openshift-ingress
+  labels:
+    use-dns01-solver: "true"
+spec:
+  secretName: apps-domain-tls
+  subject:
+    organizations:
+    - Open Cluster Management
+  usages:
+    - server auth
+    - client auth
+  dnsNames:
+    - apps.openshift-cluster-name.base-domain.tld
+    - "*.apps.openshift-cluster-name.base-domain.tld"
+  duration: 720h0m0s
+  renewBefore: 168h0m0s
+  privateKey:
+    algorithm: "RSA"
+    size: 2048
+  issuerRef:
+    name: public-issuer
+    kind: ClusterIssuer

--- a/operators/cert-manager/postinstall/apps.certificate.yaml
+++ b/operators/cert-manager/postinstall/apps.certificate.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     use-dns01-solver: "true"
 spec:
-  secretName: apps-domain-tls
+  secretName: router-certs
   subject:
     organizations:
     - Open Cluster Management

--- a/operators/cert-manager/postinstall/aws-issuer/aws.public.clusterissuer.yaml
+++ b/operators/cert-manager/postinstall/aws-issuer/aws.public.clusterissuer.yaml
@@ -1,0 +1,29 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: public-issuer
+  namespace: cert-manager
+spec:
+  acme:
+    email: acm-cicd@redhat.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: haproxy
+      selector:
+        matchLabels:
+          use-http01-solver: "true"
+    - dns01:
+        cnameStrategy: Follow
+        route53:
+          accessKeyID: NOT_MY_ACCESS_KEY
+          region: us-east-1
+          secretAccessKeySecretRef:
+            key: aws_secret_access_key
+            name: aws-creds
+      selector:
+        matchLabels:
+          use-dns01-solver: "true"

--- a/operators/cert-manager/postinstall/aws-issuer/aws.secret.example
+++ b/operators/cert-manager/postinstall/aws-issuer/aws.secret.example
@@ -1,0 +1,2 @@
+aws_access_key_id=<AWS_ACCESS_KEY_ID>
+aws_secret_access_key=<AWS_SECRET_ACCESS_KEY>

--- a/operators/cert-manager/postinstall/aws-issuer/kustomization.yaml
+++ b/operators/cert-manager/postinstall/aws-issuer/kustomization.yaml
@@ -16,13 +16,11 @@ patchesJson6902:
       path: /spec/acme/solvers/1/dns01/route53/accessKeyID
       value: 'AKIASGQYJOPGMN7U335N'
 
-namespace: cert-manager
-
 resources:
-- azure.public.clusterissuer.yaml
+- aws.public.clusterissuer.yaml
 
 secretGenerator:
-- name: azuredns-config
+- name: aws-creds
   namespace: openshift-operators
   envs:
-    - azure.secret
+    - aws.secret

--- a/operators/cert-manager/postinstall/aws-issuer/kustomization.yaml
+++ b/operators/cert-manager/postinstall/aws-issuer/kustomization.yaml
@@ -1,0 +1,28 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patchesJson6902:
+- target:
+    kind: ClusterIssuer
+    group: cert-manager.io
+    version: v1
+    name: public-issuer
+    namespace: cert-manager
+  patch: |-
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/route53/accessKeyID
+      value: 'AKIASGQYJOPGMN7U335N'
+
+namespace: cert-manager
+
+resources:
+- azure.public.clusterissuer.yaml
+
+secretGenerator:
+- name: azuredns-config
+  namespace: openshift-operators
+  envs:
+    - azure.secret

--- a/operators/cert-manager/postinstall/azure-issuer/azure.public.clusterissuer.yaml
+++ b/operators/cert-manager/postinstall/azure-issuer/azure.public.clusterissuer.yaml
@@ -1,0 +1,35 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: public-issuer
+  namespace: cert-manager
+spec:
+  acme:
+    email: acm-cicd@redhat.com
+    privateKeySecretRef:
+      name: letsencrypt-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+    - http01:
+        ingress:
+          class: haproxy
+      selector:
+        matchLabels:
+          use-http01-solver: "true"
+    - dns01:
+        cnameStrategy: Follow
+        azureDNS:
+          clientID: AZURE_CERT_MANAGER_SP_APP_ID
+          clientSecretSecretRef:
+          # The following is the secret we created in Kubernetes. Issuer will use this to present challenge to Azure DNS.
+            name: azuredns-config
+            key: client-secret
+          subscriptionID: AZURE_SUBSCRIPTION_ID
+          tenantID: AZURE_TENANT_ID
+          resourceGroupName: AZURE_DNS_ZONE_RESOURCE_GROUP
+          hostedZoneName: AZURE_DNS_ZONE
+          # Azure Cloud Environment, default to AzurePublicCloud
+          environment: AzurePublicCloud
+      selector:
+        matchLabels:
+          use-dns01-solver: "true"

--- a/operators/cert-manager/postinstall/azure-issuer/azure.secret.example
+++ b/operators/cert-manager/postinstall/azure-issuer/azure.secret.example
@@ -1,0 +1,1 @@
+client-secret="<AZURE_CLIENT_SECRET>"

--- a/operators/cert-manager/postinstall/azure-issuer/kustomization.yaml
+++ b/operators/cert-manager/postinstall/azure-issuer/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patchesJson6902:
+- target:
+    kind: ClusterIssuer
+    group: cert-manager.io
+    version: v1
+    name: public-issuer
+    namespace: cert-manager
+  patch: |-
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/clientID
+      value: 'dc22ed4f-cbdd-49fc-beb1-ea3f282b50ee'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/subscriptionID
+      value: 'c7130a18-cbc9-4b44-9307-1f56446fb730'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/tenantID
+      value: '6047c7e9-b2ad-488d-a54e-dc3f6be6a7ee'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/resourceGroupName
+      value: 'openshift4-terraform'
+    - op: replace
+      path: /spec/acme/solvers/1/dns01/azureDNS/hostedZoneName
+      value: 'az.red-chesterfield.com'
+
+resources:
+- azure.public.clusterissuer.yaml
+
+secretGenerator:
+- name: azuredns-config
+  namespace: openshift-operators
+  envs:
+    - azure.secret

--- a/operators/cert-manager/postinstall/kustomization.yaml
+++ b/operators/cert-manager/postinstall/kustomization.yaml
@@ -14,10 +14,10 @@ patchesJson6902:
   patch: |-
     - op: replace
       path: /spec/dnsNames/0
-      value: 'apps.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+      value: 'apps.hivemind-b.aws.red-chesterfield.com'
     - op: replace
       path: /spec/dnsNames/1
-      value: '*.apps.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+      value: '*.apps.hivemind-b.aws.red-chesterfield.com'
 - target:
     kind: Certificate
     group: cert-manager.io
@@ -27,12 +27,12 @@ patchesJson6902:
   patch: |-
     - op: replace
       path: /spec/dnsNames/0
-      value: 'api.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+      value: 'api.hivemind-b.aws.red-chesterfield.com'
 
 resources:
 - namespace.yaml
 - private.clusterissuer.yaml
-- azure-issuer
-# - aws-issuer
+# - azure-issuer
+- aws-issuer
 - apps.certificate.yaml
 - api.certificate.yaml

--- a/operators/cert-manager/postinstall/kustomization.yaml
+++ b/operators/cert-manager/postinstall/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+patchesJson6902:
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: apps-domain-tls-cert
+    namespace: openshift-ingress
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'apps.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+    - op: replace
+      path: /spec/dnsNames/1
+      value: '*.apps.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+- target:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: api-domain-tls-cert
+    namespace: openshift-config
+  patch: |-
+    - op: replace
+      path: /spec/dnsNames/0
+      value: 'api.aap-aas-hubs-hs6xj.az.red-chesterfield.com'
+
+resources:
+- namespace.yaml
+- private.clusterissuer.yaml
+- azure-issuer
+# - aws-issuer
+- apps.certificate.yaml
+- api.certificate.yaml

--- a/operators/cert-manager/postinstall/namespace.yaml
+++ b/operators/cert-manager/postinstall/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"

--- a/operators/cert-manager/postinstall/private.clusterissuer.yaml
+++ b/operators/cert-manager/postinstall/private.clusterissuer.yaml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: self-signed-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}

--- a/operators/cert-manager/postinstall/setup-certs-on-cluster.sh
+++ b/operators/cert-manager/postinstall/setup-certs-on-cluster.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+oc patch ingresscontroller.operator default \
+     --type=merge -p \
+     '{"spec":{"defaultCertificate": {"name": "apps-domain-tls"}}}' \
+     -n openshift-ingress-operator

--- a/operators/cert-manager/subscription.yaml
+++ b/operators/cert-manager/subscription.yaml
@@ -1,0 +1,13 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cert-manager
+  namespace: openshift-operators
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+  source: community-operators
+  sourceNamespace: openshift-marketplace

--- a/prereqs/README.md
+++ b/prereqs/README.md
@@ -1,0 +1,11 @@
+# Prereequisites
+
+You can't start rolling out OpenShift GitOps applications for Operators and Configurations without OpenShift GitOps first - this folder contains a folder to deploy the [OpenShift GitOps Operator](./openshift-gitops-operator) and [configuration for the GitOps instance and RBAC behind ArgoCD](./openshift-gitops-configuration).  
+
+## Deployment
+
+To deploy the operator and configuration in this repo:
+1. Log in to the target cluster
+2. `oc apply -f ./openshift-gitops-operator`
+3. Wait for the OpenShift GitOps Operator to signal ready (monitoring via the UI or `oc get operators`)
+4. `oc apply -f ./openshift-gitops-configuration`

--- a/prereqs/openshift-gitops-configuration/argocd.yaml
+++ b/prereqs/openshift-gitops-configuration/argocd.yaml
@@ -1,0 +1,129 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: openshift-gitops
+  namespace: openshift-gitops
+spec:
+  server:
+    autoscale:
+      enabled: false
+    grpc:
+      ingress:
+        enabled: false
+    ingress:
+      enabled: false
+    insecure: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 125m
+        memory: 128Mi
+    route:
+      enabled: true
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+    service:
+      type: ''
+  grafana:
+    enabled: false
+    ingress:
+      enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    route:
+      enabled: false
+  prometheus:
+    enabled: false
+    ingress:
+      enabled: false
+    route:
+      enabled: false
+  initialSSHKnownHosts: {}
+  resourceCustomizations: |
+    bitnami.com/SealedSecret:
+      health.lua: |
+        hs = {}
+        hs.status = "Healthy"
+        hs.message = "Controller doesnt report status"
+        return hs
+    route.openshift.io/Route:
+      ignoreDifferences: |
+        jsonPointers:
+        - /spec/host
+  applicationSet:
+    resources:
+      limits:
+        cpu: '2'
+        memory: 1Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+  rbac:
+    defaultPolicy: ''
+    policy: |
+      g, system:cluster-admins, role:admin
+      g, shared-infrastructure-admins, role:admin
+      g, admins, role:admin
+      g, aap-aas-demo-admin, role:admin
+    scopes: '[groups]'
+  repo:
+    resources:
+      limits:
+        cpu: '1'
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 256Mi
+  resourceExclusions: |
+    - apiGroups:
+      - tekton.dev
+      clusters:
+      - '*'
+      kinds:
+      - TaskRun
+      - PipelineRun
+  dex:
+    openShiftOAuth: true
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  ha:
+    enabled: false
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  tls:
+    ca: {}
+  redis:
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+  controller:
+    processors: {}
+    resources:
+      limits:
+        cpu: '2'
+        memory: 4Gi
+      requests:
+        cpu: 250m
+        memory: 1Gi

--- a/prereqs/openshift-gitops-configuration/kustomization.yaml
+++ b/prereqs/openshift-gitops-configuration/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- argocd.yaml
+- rolebinding.yaml

--- a/prereqs/openshift-gitops-configuration/rolebinding.yaml
+++ b/prereqs/openshift-gitops-configuration/rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: argocd-sa-cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/prereqs/openshift-gitops-operator/kustomization.yaml
+++ b/prereqs/openshift-gitops-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- subscription.yaml

--- a/prereqs/openshift-gitops-operator/subscription.yaml
+++ b/prereqs/openshift-gitops-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Summary of Changes

This PR adds the deployment of cert-manger as well as post-install artifacts.  